### PR TITLE
Add Korean usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# atest
+# Gugudan Express Server
+
+This project provides a simple Express-based Node.js server that displays the Korean multiplication table (구구단).
+
+## Setup
+
+Install dependencies (requires Node.js and npm):
+
+```bash
+npm install
+```
+
+## Running
+
+Start the server with:
+
+```bash
+npm start
+```
+
+The server will run on port `3000` by default. Visit `http://localhost:3000/` in your browser to view the multiplication table.
+
+## 한글 설명
+
+`npm install` 후 `npm start` 명령으로 서버를 시작할 수 있습니다. 브라우저에서 http://localhost:3000/ 주소를 열면 구구단이 출력됩니다.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gugudan-server",
+  "version": "1.0.0",
+  "description": "Express server to display Gugudan multiplication table",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  let html = '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Gugudan</title></head><body>';
+  html += '<h1>구구단</h1>';
+  html += '<table border="1" cellspacing="0" cellpadding="5">';
+  for (let i = 2; i <= 9; i++) {
+    html += '<tr>';
+    for (let j = 1; j <= 9; j++) {
+      html += `<td>${i} x ${j} = ${i * j}</td>`;
+    }
+    html += '</tr>';
+  }
+  html += '</table></body></html>';
+  res.send(html);
+});
+
+app.listen(port, () => {
+  console.log(`Gugudan app listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a small Korean section explaining how to run the server

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_685e50820a28832a920c719cdf6e815a